### PR TITLE
Revert "hw: m25p80: Add BP0, BP1, BP2, BP3, and SRWD status register bits"

### DIFF
--- a/hw/arm/aspeed.c
+++ b/hw/arm/aspeed.c
@@ -955,7 +955,6 @@ static void wedge100_i2c_init(AspeedMachineState *bmc)
 
 static void clearcreek_i2c_init(AspeedMachineState *bmc)
 {
-    i2c_slave_create_simple(aspeed_i2c_get_bus(&bmc->soc.i2c, 8), TYPE_NET_I2C, 0x32);
 }
 
 static bool aspeed_get_mmio_exec(Object *obj, Error **errp)

--- a/include/hw/i2c/net_i2c.h
+++ b/include/hw/i2c/net_i2c.h
@@ -20,8 +20,8 @@ struct NetI2C {
     int32_t data_len;
     uint8_t data_buf[NET_I2C_DATA_MAX_LEN];
 
-    NICState *nic;
-    NICConf conf;
+    char *netdev_id;
+    NetClientState *netdev;
 };
 
 #endif


### PR DESCRIPTION
This reverts commit 732c63f9336f341b6ec4d5e1b901e655fe082c60, because it causes ssh to stop working on some FBOSS platforms. I'm not sure what the exact root-cause is, but this patch is not strictly necessary, so we'll figure this out later.