### PR TITLE
hw/misc: Add i2c-netdev device

### DIFF
--- a/hw/misc/i2c-netdev.c
+++ b/hw/misc/i2c-netdev.c
@@ -1,0 +1,198 @@
+#include "qemu/osdep.h"
+#include "qemu/main-loop.h"
+#include "qapi/error.h"
+#include "hw/i2c/i2c.h"
+#include "hw/qdev-properties.h"
+#include "net/net.h"
+#include "net/eth.h"
+#include "block/aio.h"
+
+#define TYPE_I2C_NETDEV "i2c-netdev"
+OBJECT_DECLARE_SIMPLE_TYPE(I2CNetdev, I2C_NETDEV)
+
+typedef enum AsyncState AsyncState;
+enum AsyncState {
+    ASYNC_NONE,
+    ASYNC_WAITING,
+    ASYNC_DONE,
+};
+
+typedef struct I2CNetdev I2CNetdev;
+struct I2CNetdev {
+    I2CSlave parent;
+
+    I2CBus *bus;
+    NICConf nic_conf;
+    NICState *nic;
+    QEMUBH *bh;
+    AsyncState bh_bus_master;
+    AsyncState bh_transmit;
+
+    uint8_t guest_os_tx_buf[256];
+    uint8_t guest_os_rx_buf[256];
+    int guest_os_tx_pos;
+    int guest_os_rx_pos;
+    int guest_os_rx_len;
+};
+
+static int i2c_event(I2CSlave *i2c, enum i2c_event event)
+{
+    I2CNetdev *s = I2C_NETDEV(i2c);
+    NetClientState *netdev;
+
+    switch (event) {
+    case I2C_START_RECV:
+        printf("SLAVE RECEIVE UNIMPLEMENTED\n");
+        abort();
+    case I2C_START_SEND:
+        s->guest_os_tx_pos = 0;
+        break;
+    case I2C_FINISH:
+        assert(s->guest_os_tx_pos != 0);
+        netdev = qemu_get_queue(s->nic);
+        qemu_send_packet(netdev, s->guest_os_tx_buf, s->guest_os_tx_pos);
+        break;
+    case I2C_NACK:
+        printf("RECEIVE NACK UNIMPLEMENTED\n");
+        abort();
+    }
+
+    return 0;
+}
+
+static uint8_t i2c_receive(I2CSlave *i2c)
+{
+    printf("I2C NETDEV SLAVE RECEIVE UNIMPLEMENTED\n");
+    abort();
+}
+
+static int i2c_transmit(I2CSlave *i2c, uint8_t byte)
+{
+    I2CNetdev *s = I2C_NETDEV(i2c);
+
+    assert(s->guest_os_tx_pos < sizeof(s->guest_os_tx_buf));
+    s->guest_os_tx_buf[s->guest_os_tx_pos++] = byte;
+
+    return 0;
+}
+
+static bool i2c_netdev_can_receive_packet(NetClientState *nc)
+{
+    return true;
+}
+
+static ssize_t i2c_netdev_receive_packet(NetClientState *nc, const uint8_t *buf, size_t len)
+{
+    I2CNetdev *s = I2C_NETDEV(qemu_get_nic_opaque(nc));
+
+    s->guest_os_rx_len = len;
+    s->guest_os_rx_pos = 0;
+    assert(len < sizeof(s->guest_os_rx_buf));
+    memcpy(s->guest_os_rx_buf, buf, len);
+    qemu_bh_schedule(s->bh);
+
+    return len;
+}
+
+static void i2c_netdev_cleanup(NetClientState *nc)
+{
+    I2CNetdev *s = I2C_NETDEV(qemu_get_nic_opaque(nc));
+
+    s->nic = NULL;
+}
+
+static NetClientInfo net_client_info = {
+    .type = NET_CLIENT_DRIVER_NIC,
+    .size = sizeof(NetClientState),
+    .can_receive = i2c_netdev_can_receive_packet,
+    .receive = i2c_netdev_receive_packet,
+    .cleanup = i2c_netdev_cleanup,
+};
+
+static void i2c_netdev_bh(void *opaque)
+{
+    I2CNetdev *s = opaque;
+
+    switch (s->bh_bus_master) {
+    case ASYNC_NONE:
+        i2c_bus_master(s->bus, s->bh);
+        s->bh_bus_master = ASYNC_WAITING;
+        return;
+    case ASYNC_WAITING:
+        s->bh_bus_master = ASYNC_DONE;
+        break;
+    case ASYNC_DONE:
+        break;
+    }
+
+    uint8_t b;
+
+    switch (s->bh_transmit) {
+    case ASYNC_NONE:
+    case ASYNC_DONE:
+        assert(s->guest_os_rx_pos == 0);
+        assert(s->guest_os_rx_len != 0);
+        b = s->guest_os_rx_buf[s->guest_os_rx_pos++];
+        i2c_start_send(s->bus, b);
+        s->bh_transmit = ASYNC_WAITING;
+        break;
+    case ASYNC_WAITING:
+        if (s->guest_os_rx_pos >= s->guest_os_rx_len) {
+            s->bh_transmit = ASYNC_DONE;
+            s->bh_bus_master = ASYNC_NONE;
+            i2c_end_transfer(s->bus);
+            i2c_bus_release(s->bus);
+            break;
+        }
+
+        b = s->guest_os_rx_buf[s->guest_os_rx_pos++];
+        i2c_send_async(s->bus, b);
+        break;
+    }
+}
+
+static void i2c_netdev_realize(DeviceState *dev, Error **errp)
+{
+    I2CNetdev *s = I2C_NETDEV(dev);
+    s->bus = I2C_BUS(qdev_get_parent_bus(dev));
+    s->nic = qemu_new_nic(&net_client_info, &s->nic_conf, TYPE_I2C_NETDEV, dev->id, s);
+    s->bh = qemu_bh_new(i2c_netdev_bh, s);
+    s->bh_bus_master = ASYNC_NONE;
+    s->bh_transmit = ASYNC_NONE;
+    memset(s->guest_os_tx_buf, 0, sizeof(s->guest_os_tx_buf));
+    memset(s->guest_os_rx_buf, 0, sizeof(s->guest_os_rx_buf));
+    s->guest_os_tx_pos = 0;
+    s->guest_os_rx_pos = 0;
+    s->guest_os_rx_len = 0;
+}
+
+static Property i2c_netdev_props[] = {
+    DEFINE_NIC_PROPERTIES(I2CNetdev, nic_conf),
+    DEFINE_PROP_END_OF_LIST(),
+};
+
+static void i2c_netdev_class_init(ObjectClass *cls, void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(cls);
+    dc->realize = i2c_netdev_realize;
+    device_class_set_props(dc, i2c_netdev_props);
+
+    I2CSlaveClass *sc = I2C_SLAVE_CLASS(cls);
+    sc->event = i2c_event;
+    sc->recv = i2c_receive;
+    sc->send = i2c_transmit;
+}
+
+static const TypeInfo i2c_netdev = {
+    .name = TYPE_I2C_NETDEV,
+    .parent = TYPE_I2C_SLAVE,
+    .instance_size = sizeof(I2CNetdev),
+    .class_init = i2c_netdev_class_init,
+};
+
+static void register_types(void)
+{
+    type_register_static(&i2c_netdev);
+}
+
+type_init(register_types);

--- a/hw/misc/meson.build
+++ b/hw/misc/meson.build
@@ -116,7 +116,7 @@ softmmu_ss.add(when: 'CONFIG_NRF51_SOC', if_true: files('nrf51_rng.c'))
 
 softmmu_ss.add(when: 'CONFIG_GRLIB', if_true: files('grlib_ahb_apb_pnp.c'))
 
-softmmu_ss.add(when: 'CONFIG_I2C', if_true: files('i2c-echo.c'))
+softmmu_ss.add(when: 'CONFIG_I2C', if_true: files('i2c-echo.c', 'i2c-netdev.c'))
 
 specific_ss.add(when: 'CONFIG_AVR_POWER', if_true: files('avr_power.c'))
 


### PR DESCRIPTION
Adds a device that forwards and receives i2c commands from a network device, e.g. a UDP or TCP socket. In the example below, I used a UDP socket, but a TCP socket should work too.

First, create a script to receive and respond to MCTP commands from a couple sockets:

mctp.py:

    from socket import *
    import sys

    fd = socket(AF_INET, SOCK_DGRAM);
    assert fd != -1

    tx = socket(AF_INET, SOCK_DGRAM, 0)

    fd.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
    fd.bind(('', 5557))

    message = bytearray([int(arg, 16) for arg in sys.argv[1:]])

    while 1:
        pkt = fd.recv(1024)
        sys.stdout.write('Received: ')
        for b in pkt:
            sys.stdout.write('%02x ' % ord(b))
        sys.stdout.write('\n')
        sys.stdout.flush()
        tx.sendto(message, ("localhost", 5556))

Usage:

    $ python mctp.py 10 0f 19 65 01 00 00 c8 00 00 03 00 d0 7a 22 c5 16 8d eb 11 80 00 b8 ce f6 66 70 a4 1c
    Received: 0f 08 21 01 00 08 c8 00 80 03 c9

    $ ./build/qemu-system-arm -machine clearcreek-bmc \
        -drive file=flash-clearcreek,if=mtd,format=raw \
        -nographic \
        -netdev socket,id=terminus-i2c,udp=localhost:5557,localaddr=localhost:5556 \
        -device i2c-netdev,bus=aspeed.i2c.bus.8,address=0x32,netdev=terminus-i2c

    // Within clearcreek console, disable ipmbd_0 and ipmbd_8
    bmc-oob:~# sv stop ipmbd_0
    bmc-oob:~# sv stop ipmbd_8
    // Send a test command, run mctp.py outside QEMU to generate a response
    bmc-oob:~# mctp-util -d 8 0x64 0 0 0x80 3
    core: Generating packets for transmission of 3 byte message from 8 to 0
    core: Enqueued 1 packets
    smbus: >TX> 0F 08 21 01 00 08 C8 00 80 03 C9
    smbus: <RX< 20 0F 19 65 01 00 00 C8 00 00 03 00 D0 7A 22 C5 16 8D EB 11 80 00 B8 CE F6 66 70 A4 1C
    raw response:
    08 14 00 00 03 00 d0 7a 22 c5 16 8d eb 11 80 00 b8 ce f6 66 70 a4

    MCTP transport header: src_eid(08) tag(14)
    MCTP header:           msg_type(00)

    MCTP control message
      Rq[7],D[6],IID[4:0]: 00
      Command Code:        03
      Completion Code:     00
      response data:       d0 7a 22 c5 16 8d eb 11 80 00 b8 ce f6 66 70 a4