### PR TITLE
hw: m25p80: add block protect bits

### DIFF
--- a/tests/qtest/aspeed_smc-test.c
+++ b/tests/qtest/aspeed_smc-test.c
@@ -450,6 +450,140 @@ static void test_status_reg_write_protection(void)
     flash_reset();
 }
 
+static void test_write_block_protect(void)
+{
+    uint32_t page_addr_255 = 0xff0000; /* sector 255 */
+    uint32_t page_addr_256 = 0x1000000; /* sector 256 */
+    uint32_t page_addr_510 = 0x1fe0000; /* sector 510 */
+    uint32_t page_addr_511 = 0x1ff0000; /* sector 511 */
+    uint32_t page[FLASH_PAGE_SIZE / 4];
+    int i;
+
+    spi_ce_ctrl(1 << CRTL_EXTENDED0);
+    spi_conf(CONF_ENABLE_W0);
+
+    /* Default case: all sectors unprotected */
+    spi_ctrl_start_user();
+    writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
+    writeb(ASPEED_FLASH_BASE, WREN);
+    spi_ctrl_stop_user();
+    spi_ctrl_setmode(CTRL_WRITEMODE, PP);
+    /* Attempt to write to sector 0, 256, and 511 */
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        writel(ASPEED_FLASH_BASE + i * 4, make_be32(0xabcdef12));
+        writel(ASPEED_FLASH_BASE + page_addr_256 + i * 4,
+               make_be32(0xabcdef13));
+        writel(ASPEED_FLASH_BASE + page_addr_511 + i * 4,
+               make_be32(0xabcdef14));
+    }
+    /* Check all memory is written */
+    read_page_mem(0, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xabcdef12);
+    }
+    read_page_mem(page_addr_256, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xabcdef13);
+    }
+    read_page_mem(page_addr_511, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xabcdef14);
+    }
+
+    /* Sector 511 protected: BP0 = 1 */
+    spi_ctrl_start_user();
+    writeb(ASPEED_FLASH_BASE, WREN);
+    writeb(ASPEED_FLASH_BASE, BULK_ERASE);
+    writeb(ASPEED_FLASH_BASE, WREN);
+    writeb(ASPEED_FLASH_BASE, WRSR);
+    writeb(ASPEED_FLASH_BASE, 0x4);
+    writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
+    writeb(ASPEED_FLASH_BASE, WREN);
+    spi_ctrl_stop_user();
+    spi_ctrl_setmode(CTRL_WRITEMODE, PP);
+    /* Attempt to write to sector 510 and 511 */
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        writel(ASPEED_FLASH_BASE + page_addr_510 + i * 4,
+               make_be32(0xabcdef12));
+        writel(ASPEED_FLASH_BASE + page_addr_511 + i * 4,
+               make_be32(0xabcdef12));
+    }
+    /* Check sector 510 is written */
+    read_page_mem(page_addr_510, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xabcdef12);
+    }
+    /* Check sector 511 is not written */
+    read_page_mem(page_addr_511, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xffffffff);
+    }
+
+    /* Sectors 256 to 511 are protected: BP0, BP3 = 1 */
+    spi_ctrl_start_user();
+    writeb(ASPEED_FLASH_BASE, WREN);
+    writeb(ASPEED_FLASH_BASE, BULK_ERASE);
+    writeb(ASPEED_FLASH_BASE, WREN);
+    writeb(ASPEED_FLASH_BASE, WRSR);
+    writeb(ASPEED_FLASH_BASE, 0x44);
+    writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
+    writeb(ASPEED_FLASH_BASE, WREN);
+    spi_ctrl_stop_user();
+    spi_ctrl_setmode(CTRL_WRITEMODE, PP);
+    /* Attempt to write to sector 256 (protected) and 255 (unprotected) */
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        writel(ASPEED_FLASH_BASE + page_addr_255 + i * 4,
+               make_be32(0xabcdef12));
+        writel(ASPEED_FLASH_BASE + page_addr_256 + i * 4,
+               make_be32(0xabcdef12));
+    }
+    /* Check sector 255 is written */
+    read_page_mem(page_addr_255, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xabcdef12);
+    }
+    /* Check sector 256 is not written */
+    read_page_mem(page_addr_256, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xffffffff);
+    }
+
+    /* All sectors are protected: BP0, BP1, BP2, BP3 = 1 */
+    spi_ctrl_start_user();
+    writeb(ASPEED_FLASH_BASE, WREN);
+    writeb(ASPEED_FLASH_BASE, BULK_ERASE);
+    writeb(ASPEED_FLASH_BASE, WREN);
+    writeb(ASPEED_FLASH_BASE, WRSR);
+    writeb(ASPEED_FLASH_BASE, 0x5C);
+    writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
+    writeb(ASPEED_FLASH_BASE, WREN);
+    spi_ctrl_stop_user();
+    spi_ctrl_setmode(CTRL_WRITEMODE, PP);
+    /* Attempt to write to sector 0, 256, 511 */
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        writel(ASPEED_FLASH_BASE + i * 4, make_be32(0xabcdef12));
+        writel(ASPEED_FLASH_BASE + page_addr_256 + i * 4,
+               make_be32(0xabcdef12));
+        writel(ASPEED_FLASH_BASE + page_addr_511 + i * 4,
+               make_be32(0xabcdef12));
+    }
+    /* Check that no memory is written */
+    read_page_mem(0, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xffffffff);
+    }
+    read_page_mem(page_addr_256, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xffffffff);
+    }
+    read_page_mem(page_addr_511, page);
+    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, 0xffffffff);
+    }
+
+    flash_reset();
+}
+
 static char tmp_path[] = "/tmp/qtest.m25p80.XXXXXX";
 
 int main(int argc, char **argv)
@@ -478,6 +612,8 @@ int main(int argc, char **argv)
     qtest_add_func("/ast2400/smc/read_status_reg", test_read_status_reg);
     qtest_add_func("/ast2400/smc/status_reg_write_protection",
                    test_status_reg_write_protection);
+    qtest_add_func("/ast2400/smc/write_block_protect",
+                   test_write_block_protect);
 
     ret = g_test_run();
 


### PR DESCRIPTION
Signed-off-by: Iris Chen <irischenlj@fb.com>

Adding BP0, BP1, BP2, BP3 for memory write protection