### PR TITLE
Fixing individual test failure when tests are running in isolation

### DIFF
--- a/hw/block/m25p80.c
+++ b/hw/block/m25p80.c
@@ -43,6 +43,7 @@
 /* erase capabilities */
 #define ER_4K 1
 #define ER_32K 2
+#define SNOR_F_HAS_SR_TB BIT(3)
 #define SNOR_F_HAS_SR_BP3_BIT6 BIT(10)
 /* set to allow the page program command to write 0s back to 1. Useful for
  * modelling EEPROM with SPI flash command set
@@ -255,7 +256,7 @@ static const FlashPartInfo known_devices[] = {
     { INFO("n25q512a13",  0x20ba20,      0,  64 << 10, 1024, ER_4K) },
     { INFO("n25q128",     0x20ba18,      0,  64 << 10, 256, 0) },
     { INFO("n25q256a",    0x20ba19,      0,  64 << 10, 512,
-           ER_4K | SNOR_F_HAS_SR_BP3_BIT6) },
+           ER_4K | SNOR_F_HAS_SR_BP3_BIT6 | SNOR_F_HAS_SR_TB) },
     { INFO("n25q512a",    0x20ba20,      0,  64 << 10, 1024, ER_4K) },
     { INFO("n25q512ax3",  0x20ba20,  0x1000,  64 << 10, 1024, ER_4K) },
     { INFO("mt25ql512ab", 0x20ba20, 0x1044, 64 << 10, 1024, ER_4K | ER_32K) },
@@ -486,6 +487,7 @@ struct Flash {
     bool block_protect1;
     bool block_protect2;
     bool block_protect3;
+    bool top_bottom_bit;
     bool status_register_write_disabled;
     uint8_t ear;
 
@@ -641,12 +643,21 @@ void flash_write8(Flash *s, uint32_t addr, uint8_t data)
                                    (s->block_protect1 << 1) |
                                    (s->block_protect0 << 0);
 
-    if (block_protect_value > 0) {
-        uint32_t num_protected_sectors = 1 << (block_protect_value - 1);
-        uint32_t sector = addr / s->pi->sector_size;
+     uint32_t num_protected_sectors = 1 << (block_protect_value - 1);
+     uint32_t sector = addr / s->pi->sector_size;
 
-        if (s->pi->n_sectors <= sector + num_protected_sectors) {
-            qemu_log_mask(LOG_GUEST_ERROR, "M25P80: write with write protect!\n");
+     /* top_bottom_bit == 0 means TOP */
+    if (!s->top_bottom_bit) {
+        if (block_protect_value > 0 &&
+            s->pi->n_sectors <= sector + num_protected_sectors) {
+            qemu_log_mask(LOG_GUEST_ERROR,
+                          "M25P80: write with write protect!\n");
+            return;
+        }
+    } else {
+        if (block_protect_value > 0 && sector < num_protected_sectors) {
+            qemu_log_mask(LOG_GUEST_ERROR,
+                          "M25P80: write with write protect!\n");
             return;
         }
     }
@@ -764,6 +775,9 @@ static void complete_collecting_data(Flash *s)
         s->block_protect0 = extract32(s->data[0], 2, 1);
         s->block_protect1 = extract32(s->data[0], 3, 1);
         s->block_protect2 = extract32(s->data[0], 4, 1);
+        if (s->pi->flags & SNOR_F_HAS_SR_TB) {
+            s->top_bottom_bit = extract32(s->data[0], 5, 1);
+        }
         if (s->pi->flags & SNOR_F_HAS_SR_BP3_BIT6) {
             s->block_protect3 = extract32(s->data[0], 6, 1);
         }
@@ -1242,6 +1256,9 @@ static void decode_new_cmd(Flash *s, uint32_t value)
         s->data[0] |= (!!s->block_protect0) << 2;
         s->data[0] |= (!!s->block_protect1) << 3;
         s->data[0] |= (!!s->block_protect2) << 4;
+        if (s->pi->flags & SNOR_F_HAS_SR_TB) {
+            s->data[0] |= (!!s->top_bottom_bit) << 5;
+        }
         if (s->pi->flags & SNOR_F_HAS_SR_BP3_BIT6) {
             s->data[0] |= (!!s->block_protect3) << 6;
         }
@@ -1590,6 +1607,7 @@ static void m25p80_reset(DeviceState *d)
     s->block_protect1 = false;
     s->block_protect2 = false;
     s->block_protect3 = false;
+    s->top_bottom_bit = false;
 
     reset_memory(s);
 }

--- a/hw/block/m25p80.c
+++ b/hw/block/m25p80.c
@@ -916,6 +916,7 @@ static void reset_memory(Flash *s)
         break;
     }
 
+    memset(s->storage, 0xff, s->size);
     trace_m25p80_reset_done(s);
 }
 

--- a/tests/qtest/aspeed_smc-test.c
+++ b/tests/qtest/aspeed_smc-test.c
@@ -189,6 +189,22 @@ static void read_page_mem(uint32_t addr, uint32_t *page)
     }
 }
 
+static void mem_set_page(uint32_t addr, uint32_t write_value)
+{
+    for (int i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        writel(addr + i * 4, write_value);
+    }
+}
+
+static void mem_verify_page(uint32_t addr, uint32_t expected_value)
+{
+    uint32_t page[FLASH_PAGE_SIZE / 4];
+    read_page_mem(addr, page);
+    for (int i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
+        g_assert_cmphex(page[i], ==, expected_value);
+    }
+}
+
 static void test_erase_sector(void)
 {
     uint32_t some_page_addr = 0x600 * FLASH_PAGE_SIZE;
@@ -452,133 +468,144 @@ static void test_status_reg_write_protection(void)
 
 static void test_write_block_protect(void)
 {
-    uint32_t page_addr_255 = 0xff0000; /* sector 255 */
-    uint32_t page_addr_256 = 0x1000000; /* sector 256 */
-    uint32_t page_addr_510 = 0x1fe0000; /* sector 510 */
-    uint32_t page_addr_511 = 0x1ff0000; /* sector 511 */
-    uint32_t page[FLASH_PAGE_SIZE / 4];
-    int i;
+    uint32_t sector_size = 65536;
+    uint32_t n_sectors = 512;
 
     spi_ce_ctrl(1 << CRTL_EXTENDED0);
     spi_conf(CONF_ENABLE_W0);
 
-    /* Default case: all sectors unprotected */
-    spi_ctrl_start_user();
-    writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
-    writeb(ASPEED_FLASH_BASE, WREN);
-    spi_ctrl_stop_user();
-    spi_ctrl_setmode(CTRL_WRITEMODE, PP);
-    /* Attempt to write to sector 0, 256, and 511 */
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        writel(ASPEED_FLASH_BASE + i * 4, make_be32(0xabcdef12));
-        writel(ASPEED_FLASH_BASE + page_addr_256 + i * 4,
-               make_be32(0xabcdef13));
-        writel(ASPEED_FLASH_BASE + page_addr_511 + i * 4,
-               make_be32(0xabcdef14));
-    }
-    /* Check all memory is written */
-    read_page_mem(0, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xabcdef12);
-    }
-    read_page_mem(page_addr_256, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xabcdef13);
-    }
-    read_page_mem(page_addr_511, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xabcdef14);
+    uint32_t bp_bits = 0b00000000;
+
+    for (int i = 0; i < 16; i++) {
+        spi_ctrl_start_user();
+        writeb(ASPEED_FLASH_BASE, WREN);
+        writeb(ASPEED_FLASH_BASE, BULK_ERASE);
+        writeb(ASPEED_FLASH_BASE, WREN);
+        writeb(ASPEED_FLASH_BASE, WRSR);
+        writeb(ASPEED_FLASH_BASE, bp_bits);
+        writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
+        writeb(ASPEED_FLASH_BASE, WREN);
+        spi_ctrl_stop_user();
+
+        bp_bits += 0b100;
+        /* After 7, BP3 is set */
+        if (i == 7) {
+            bp_bits = 0b1000000;
+        }
+
+        spi_ctrl_setmode(CTRL_WRITEMODE, PP);
+
+        if (i == 0) {
+            /* Check all sectors can be written */
+            for (int sector = 0; sector < n_sectors; sector++) {
+                uint32_t addr = sector * sector_size;
+                mem_set_page(ASPEED_FLASH_BASE + addr, make_be32(0xabcdef12));
+            }
+            for (int sector = 0; sector < n_sectors; sector++) {
+                uint32_t addr = sector * sector_size;
+                mem_verify_page(addr, 0xabcdef12);
+            }
+        } else if (i > 9) {
+            /* Check all sectors can not be written */
+            for (int sector = 0; sector < n_sectors; sector++) {
+                uint32_t addr = sector * sector_size;
+                mem_set_page(ASPEED_FLASH_BASE + addr, make_be32(0xabcdef12));
+            }
+            for (int sector = 0; sector < n_sectors; sector++) {
+                uint32_t addr = sector * sector_size;
+                mem_verify_page(addr, 0xffffffff);
+            }
+        } else {
+             /*
+              * Check the protected sector cannot be written and
+              * the unprotected sector below it can be written
+              */
+             /* bpv = block_protect_value */
+             uint32_t bpv = 1 << (i - 1);
+             uint32_t unprotected_addr = (n_sectors - bpv - 1) * sector_size;
+             uint32_t protected_addr = (n_sectors - bpv) * sector_size;
+
+             mem_set_page(ASPEED_FLASH_BASE + unprotected_addr,
+                          make_be32(0xabcdef12));
+             mem_set_page(ASPEED_FLASH_BASE + protected_addr,
+                          make_be32(0xabcdef12));
+
+             mem_verify_page(unprotected_addr, 0xabcdef12);
+             mem_verify_page(protected_addr, 0xffffffff);
+        }
     }
 
-    /* Sector 511 protected: BP0 = 1 */
-    spi_ctrl_start_user();
-    writeb(ASPEED_FLASH_BASE, WREN);
-    writeb(ASPEED_FLASH_BASE, BULK_ERASE);
-    writeb(ASPEED_FLASH_BASE, WREN);
-    writeb(ASPEED_FLASH_BASE, WRSR);
-    writeb(ASPEED_FLASH_BASE, 0x4);
-    writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
-    writeb(ASPEED_FLASH_BASE, WREN);
-    spi_ctrl_stop_user();
-    spi_ctrl_setmode(CTRL_WRITEMODE, PP);
-    /* Attempt to write to sector 510 and 511 */
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        writel(ASPEED_FLASH_BASE + page_addr_510 + i * 4,
-               make_be32(0xabcdef12));
-        writel(ASPEED_FLASH_BASE + page_addr_511 + i * 4,
-               make_be32(0xabcdef12));
-    }
-    /* Check sector 510 is written */
-    read_page_mem(page_addr_510, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xabcdef12);
-    }
-    /* Check sector 511 is not written */
-    read_page_mem(page_addr_511, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xffffffff);
-    }
+    flash_reset();
+}
 
-    /* Sectors 256 to 511 are protected: BP0, BP3 = 1 */
-    spi_ctrl_start_user();
-    writeb(ASPEED_FLASH_BASE, WREN);
-    writeb(ASPEED_FLASH_BASE, BULK_ERASE);
-    writeb(ASPEED_FLASH_BASE, WREN);
-    writeb(ASPEED_FLASH_BASE, WRSR);
-    writeb(ASPEED_FLASH_BASE, 0x44);
-    writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
-    writeb(ASPEED_FLASH_BASE, WREN);
-    spi_ctrl_stop_user();
-    spi_ctrl_setmode(CTRL_WRITEMODE, PP);
-    /* Attempt to write to sector 256 (protected) and 255 (unprotected) */
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        writel(ASPEED_FLASH_BASE + page_addr_255 + i * 4,
-               make_be32(0xabcdef12));
-        writel(ASPEED_FLASH_BASE + page_addr_256 + i * 4,
-               make_be32(0xabcdef12));
-    }
-    /* Check sector 255 is written */
-    read_page_mem(page_addr_255, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xabcdef12);
-    }
-    /* Check sector 256 is not written */
-    read_page_mem(page_addr_256, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xffffffff);
-    }
+static void test_write_block_protect_bottom_bit(void)
+{
+    uint32_t sector_size = 65536;
+    uint32_t n_sectors = 512;
 
-    /* All sectors are protected: BP0, BP1, BP2, BP3 = 1 */
-    spi_ctrl_start_user();
-    writeb(ASPEED_FLASH_BASE, WREN);
-    writeb(ASPEED_FLASH_BASE, BULK_ERASE);
-    writeb(ASPEED_FLASH_BASE, WREN);
-    writeb(ASPEED_FLASH_BASE, WRSR);
-    writeb(ASPEED_FLASH_BASE, 0x5C);
-    writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
-    writeb(ASPEED_FLASH_BASE, WREN);
-    spi_ctrl_stop_user();
-    spi_ctrl_setmode(CTRL_WRITEMODE, PP);
-    /* Attempt to write to sector 0, 256, 511 */
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        writel(ASPEED_FLASH_BASE + i * 4, make_be32(0xabcdef12));
-        writel(ASPEED_FLASH_BASE + page_addr_256 + i * 4,
-               make_be32(0xabcdef12));
-        writel(ASPEED_FLASH_BASE + page_addr_511 + i * 4,
-               make_be32(0xabcdef12));
-    }
-    /* Check that no memory is written */
-    read_page_mem(0, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xffffffff);
-    }
-    read_page_mem(page_addr_256, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xffffffff);
-    }
-    read_page_mem(page_addr_511, page);
-    for (i = 0; i < FLASH_PAGE_SIZE / 4; i++) {
-        g_assert_cmphex(page[i], ==, 0xffffffff);
+    spi_ce_ctrl(1 << CRTL_EXTENDED0);
+    spi_conf(CONF_ENABLE_W0);
+
+    /* top bottom bit is enabled */
+    uint32_t bp_bits = 0b00100000;
+
+    for (int i = 0; i < 16; i++) {
+        spi_ctrl_start_user();
+        writeb(ASPEED_FLASH_BASE, WREN);
+        writeb(ASPEED_FLASH_BASE, BULK_ERASE);
+        writeb(ASPEED_FLASH_BASE, WREN);
+        writeb(ASPEED_FLASH_BASE, WRSR);
+        writeb(ASPEED_FLASH_BASE, bp_bits);
+        writeb(ASPEED_FLASH_BASE, EN_4BYTE_ADDR);
+        writeb(ASPEED_FLASH_BASE, WREN);
+        spi_ctrl_stop_user();
+
+        bp_bits += 0b100;
+        /* After 7, BP3 is set */
+        if (i == 7) {
+            bp_bits = 0b1100000;
+        }
+
+        spi_ctrl_setmode(CTRL_WRITEMODE, PP);
+
+        if (i == 0) {
+            /* Check all sectors can be written */
+            for (int sector = 0; sector < n_sectors; sector++) {
+                uint32_t addr = sector * sector_size;
+                mem_set_page(ASPEED_FLASH_BASE + addr, make_be32(0xabcdef12));
+            }
+            for (int sector = 0; sector < n_sectors; sector++) {
+                uint32_t addr = sector * sector_size;
+                mem_verify_page(addr, 0xabcdef12);
+            }
+        } else if (i > 9) {
+            /* Check all sectors can not be written */
+            for (int sector = 0; sector < n_sectors; sector++) {
+                uint32_t addr = sector * sector_size;
+                mem_set_page(ASPEED_FLASH_BASE + addr, make_be32(0xabcdef12));
+            }
+            for (int sector = 0; sector < n_sectors; sector++) {
+                uint32_t addr = sector * sector_size;
+                mem_verify_page(addr, 0xffffffff);
+            }
+        } else {
+             /*
+              * Check the protected sector cannot be written and
+              * the unprotected sector below it can be written
+              */
+             /* bpv = block_protect_value */
+             uint32_t bpv = 1 << (i - 1);
+             uint32_t unprotected_addr = bpv * sector_size;
+             uint32_t protected_addr = (bpv - 1) * sector_size;
+
+             mem_set_page(ASPEED_FLASH_BASE + unprotected_addr,
+                          make_be32(0xabcdef12));
+             mem_set_page(ASPEED_FLASH_BASE + protected_addr,
+                          make_be32(0xabcdef12));
+
+             mem_verify_page(unprotected_addr, 0xabcdef12);
+             mem_verify_page(protected_addr, 0xffffffff);
+        }
     }
 
     flash_reset();
@@ -614,6 +641,8 @@ int main(int argc, char **argv)
                    test_status_reg_write_protection);
     qtest_add_func("/ast2400/smc/write_block_protect",
                    test_write_block_protect);
+    qtest_add_func("/ast2400/smc/write_block_protect_bottom_bit",
+                   test_write_block_protect_bottom_bit);
 
     ret = g_test_run();
 


### PR DESCRIPTION
There exists some interference between the tests causing some tests to fail in isolation but pass when run altogether. 

This patch fixes that and allows all the tests to run in isolation by adding bulk erase into `reset_memory` and fixing the tests so they do not depend on each other. 

The problem before: (example of `"/ast2400/smc/write_page_mem"` from main)
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/46090544/171253415-f29c3676-fadd-472f-807a-4459b1e30015.png">

Now: 
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/46090544/171296533-8b268473-bb69-4c00-b4e0-5540ec73033b.png">

