### PR TITLE
hw: ssi: add new spi gpio controller

### DIFF
--- a/hw/arm/Kconfig
+++ b/hw/arm/Kconfig
@@ -455,6 +455,7 @@ config ASPEED_SOC
     select EMC141X
     select UNIMP
     select LED
+    select SPI_GPIO
 
 config MPS2
     bool

--- a/hw/arm/aspeed.c
+++ b/hw/arm/aspeed.c
@@ -28,6 +28,7 @@
 #include "hw/qdev-clock.h"
 #include "hw/nvram/eeprom_at24c.h"
 #include "fby35.h"
+#include "hw/ssi/spi_gpio.h"
 
 static struct arm_boot_info aspeed_board_binfo = {
     .board_id = -1, /* device-tree-only board */
@@ -175,6 +176,11 @@ struct AspeedMachineState {
 /* TODO: Leave same as EVB for now. */
 #define BLETCHLEY_BMC_HW_STRAP1 AST2600_EVB_HW_STRAP1
 #define BLETCHLEY_BMC_HW_STRAP2 AST2600_EVB_HW_STRAP2
+
+/* ASPEED GPIO propname values */
+#define AST_GPIO_IRQ_X0_NUM 185
+#define AST_GPIO_IRQ_X3_NUM 188
+#define AST_GPIO_IRQ_X4_NUM 189
 
 /*
  * The max ram region is for firmwares that scan the address space
@@ -370,6 +376,24 @@ static void aspeed_machine_init(MachineState *machine)
     qdev_prop_set_uint32(DEVICE(&bmc->soc), "uart-default",
                          amc->uart_default);
     qdev_realize(DEVICE(&bmc->soc), NULL, &error_abort);
+
+    SpiGpioState *spi_gpio = SPI_GPIO(qdev_new(TYPE_SPI_GPIO));
+    spi_gpio->aspeed_gpio = &bmc->soc.gpio;
+    qdev_realize(DEVICE(spi_gpio), NULL, &error_fatal);
+
+    DeviceState *m25p80 = qdev_new("n25q256a");
+    qdev_realize(m25p80, BUS(spi_gpio->spi), &error_fatal);
+
+    qdev_connect_gpio_out_named(DEVICE(&bmc->soc.gpio), "sysbus-irq", AST_GPIO_IRQ_X0_NUM,
+                                qdev_get_gpio_in_named(DEVICE(spi_gpio), "SPI_CS_in", 0));
+    qdev_connect_gpio_out_named(DEVICE(&bmc->soc.gpio), "sysbus-irq", AST_GPIO_IRQ_X3_NUM,
+                                qdev_get_gpio_in_named(DEVICE(spi_gpio), "SPI_CLK", 0));
+    qdev_connect_gpio_out_named(DEVICE(&bmc->soc.gpio), "sysbus-irq", AST_GPIO_IRQ_X4_NUM,
+                                qdev_get_gpio_in_named(DEVICE(spi_gpio), "SPI_MOSI", 0));
+
+    qdev_connect_gpio_out_named(DEVICE(spi_gpio), "SPI_CS_out", 0,
+                                qdev_get_gpio_in_named(m25p80, SSI_GPIO_CS, 0));
+    object_property_set_bool(OBJECT(spi_gpio->aspeed_gpio), "gpioX5", true, &error_fatal);
 
     memory_region_add_subregion(get_system_memory(),
                                 sc->memmap[ASPEED_DEV_SDRAM],

--- a/hw/ssi/Kconfig
+++ b/hw/ssi/Kconfig
@@ -20,3 +20,7 @@ config XILINX_SPIPS
 config STM32F2XX_SPI
     bool
     select SSI
+
+config SPI_GPIO
+    bool
+    select SSI

--- a/hw/ssi/meson.build
+++ b/hw/ssi/meson.build
@@ -1,4 +1,5 @@
 softmmu_ss.add(when: 'CONFIG_ASPEED_SOC', if_true: files('aspeed_smc.c'))
+softmmu_ss.add(when: 'CONFIG_SPI_GPIO', if_true: files('spi_gpio.c'))
 softmmu_ss.add(when: 'CONFIG_MSF2', if_true: files('mss-spi.c'))
 softmmu_ss.add(when: 'CONFIG_NPCM7XX', if_true: files('npcm7xx_fiu.c'))
 softmmu_ss.add(when: 'CONFIG_PL022', if_true: files('pl022.c'))

--- a/hw/ssi/spi_gpio.c
+++ b/hw/ssi/spi_gpio.c
@@ -1,0 +1,88 @@
+/*
+ * QEMU model of the SPI GPIO controller
+ *
+ * Copyright (C)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "hw/ssi/spi_gpio.h"
+#include "hw/irq.h"
+
+static void cs_handler(void *opaque, int n, int level)
+{
+    SpiGpioState *s = SPI_GPIO(opaque);
+    s->cs = !!level;
+
+    /* relay the CS value to the CS output pin */
+    qemu_set_irq(s->cs_output_pin, s->cs);
+}
+
+static void clk_handler(void *opaque, int n, int level)
+{
+    SpiGpioState *s = SPI_GPIO(opaque);
+    s->clk = !!level;
+}
+
+static void mosi_handler(void *opaque, int n, int level)
+{
+    SpiGpioState *s = SPI_GPIO(opaque);
+    s->mosi = !!level;
+}
+
+static void spi_gpio_realize(DeviceState *dev, Error **errp)
+{
+    SpiGpioState *s = SPI_GPIO(dev);
+
+    s->spi = ssi_create_bus(dev, "spi");
+
+    s->cs = 1;
+    s->clk = 1;
+    s->mosi = 1;
+
+    /* init the input GPIO lines */
+    qdev_init_gpio_in_named(dev, cs_handler, "SPI_CS_in", 1);
+    qdev_init_gpio_in_named(dev, clk_handler, "SPI_CLK", 1);
+    qdev_init_gpio_in_named(dev, mosi_handler, "SPI_MOSI", 1);
+
+    /* init the output GPIO lines */
+    qdev_init_gpio_out_named(dev, &s->miso_output_pin, "SPI_MISO", 1);
+    qdev_init_gpio_out_named(dev, &s->cs_output_pin, "SPI_CS_out", 1);
+}
+
+static void SPI_GPIO_class_init(ObjectClass *klass, void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+
+    dc->realize = spi_gpio_realize;
+}
+
+static const TypeInfo SPI_GPIO_info = {
+    .name           = TYPE_SPI_GPIO,
+    .parent         = TYPE_DEVICE,
+    .instance_size  = sizeof(SpiGpioState),
+    .class_init     = SPI_GPIO_class_init,
+};
+
+static void SPI_GPIO_register_types(void)
+{
+    type_register_static(&SPI_GPIO_info);
+}
+
+type_init(SPI_GPIO_register_types)

--- a/include/hw/ssi/spi_gpio.h
+++ b/include/hw/ssi/spi_gpio.h
@@ -1,0 +1,44 @@
+/*
+ * QEMU model of the SPI GPIO controller
+ *
+ * Copyright (C)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef SPI_GPIO_H
+#define SPI_GPIO_H
+
+#include "qemu/osdep.h"
+#include "hw/ssi/ssi.h"
+#include "hw/gpio/aspeed_gpio.h"
+
+#define TYPE_SPI_GPIO "spi_gpio"
+OBJECT_DECLARE_SIMPLE_TYPE(SpiGpioState, SPI_GPIO);
+
+struct SpiGpioState {
+    DeviceState parent;
+    SSIBus *spi;
+    AspeedGPIOState *aspeed_gpio;
+
+    int clk, mosi, cs;
+    qemu_irq miso_output_pin, cs_output_pin;
+};
+
+#endif /* SPI_GPIO_H */


### PR DESCRIPTION
Signed-off-by: Iris Chen <irischenlj@fb.com>

Add new spi gpio controller associated with cs, sck, miso and mosi GPIOs
Draft PR here with previous comments: https://github.com/chen-iris/openbmc-qemu/pull/2