### PR TITLE
hw: ssi: add decoding/encoding logic to spi gpio controller

### DIFF
--- a/hw/ssi/spi_gpio.c
+++ b/hw/ssi/spi_gpio.c
@@ -25,22 +25,91 @@
 #include "hw/ssi/spi_gpio.h"
 #include "hw/irq.h"
 
-static void cs_handler(void *opaque, int n, int level)
+#define SPI_CPHA BIT(0) /* clock phase (1 = SPI_CLOCK_PHASE_SECOND) */
+#define SPI_CPOL BIT(1) /* clock polarity (1 = SPI_POLARITY_HIGH) */
+
+static void do_leading_edge(SpiGpioState *s)
+{
+    if (s->CPHA) {
+        s->miso = !!(s->output_byte & 0x80);
+        object_property_set_bool(OBJECT(s->aspeed_gpio),
+                                 "gpioX5", s->miso, NULL);
+    } else {
+        s->input_byte |= s->mosi ? 1 : 0;
+    }
+}
+
+static void do_trailing_edge(SpiGpioState *s)
+{
+    if (s->CPHA) {
+        s->output_byte |= s->mosi ? 1 : 0;
+    } else {
+        s->miso = !!(s->output_byte & 0x80);
+        object_property_set_bool(OBJECT(s->aspeed_gpio),
+                                 "gpioX5", s->miso, NULL);
+    }
+}
+
+static void cs_set_level(void *opaque, int n, int level)
 {
     SpiGpioState *s = SPI_GPIO(opaque);
     s->cs = !!level;
 
     /* relay the CS value to the CS output pin */
     qemu_set_irq(s->cs_output_pin, s->cs);
+
+    s->miso = !!(s->output_byte & 0x80);
+    object_property_set_bool(OBJECT(s->aspeed_gpio),
+                             "gpioX5", s->miso, NULL);
+
+    s->clk = !!(s->mode & SPI_CPOL);
 }
 
-static void clk_handler(void *opaque, int n, int level)
+static void clk_set_level(void *opaque, int n, int level)
 {
     SpiGpioState *s = SPI_GPIO(opaque);
-    s->clk = !!level;
+
+    bool cur = !!level;
+
+    /* CS# is high/not selected, do nothing */
+    if (s->cs) {
+        return;
+    }
+
+    /* When the lock has not changed, do nothing */
+    if (s->clk == cur) {
+        return;
+    }
+
+    s->clk = cur;
+
+    /* Leading edge */
+    if (s->clk != s->CIDLE) {
+        do_leading_edge(s);
+    }
+
+    /* Trailing edge */
+    if (s->clk == s->CIDLE) {
+        do_trailing_edge(s);
+        s->clk_counter++;
+
+        /*
+         * Deliver the input to and
+         * get the next output byte
+         * from the SPI device
+         */
+        if (s->clk_counter == 8) {
+            s->output_byte = ssi_transfer(s->spi, s->input_byte);
+            s->clk_counter = 0;
+            s->input_byte = 0;
+         } else {
+            s->input_byte <<= 1;
+            s->output_byte <<= 1;
+         }
+    }
 }
 
-static void mosi_handler(void *opaque, int n, int level)
+static void mosi_set_level(void *opaque, int n, int level)
 {
     SpiGpioState *s = SPI_GPIO(opaque);
     s->mosi = !!level;
@@ -52,14 +121,22 @@ static void spi_gpio_realize(DeviceState *dev, Error **errp)
 
     s->spi = ssi_create_bus(dev, "spi");
 
-    s->cs = 1;
-    s->clk = 1;
-    s->mosi = 1;
+    s->mode = 0;
+    s->clk_counter = 0;
+
+    s->cs = true;
+    s->clk = true;
+    s->mosi = true;
+
+    /* Assuming the first output byte is 0 */
+    s->output_byte = 0;
+    s->CIDLE = !!(s->mode & SPI_CPOL);
+    s->CPHA = !!(s->mode & SPI_CPHA);
 
     /* init the input GPIO lines */
-    qdev_init_gpio_in_named(dev, cs_handler, "SPI_CS_in", 1);
-    qdev_init_gpio_in_named(dev, clk_handler, "SPI_CLK", 1);
-    qdev_init_gpio_in_named(dev, mosi_handler, "SPI_MOSI", 1);
+    qdev_init_gpio_in_named(dev, cs_set_level, "SPI_CS_in", 1);
+    qdev_init_gpio_in_named(dev, clk_set_level, "SPI_CLK", 1);
+    qdev_init_gpio_in_named(dev, mosi_set_level, "SPI_MOSI", 1);
 
     /* init the output GPIO lines */
     qdev_init_gpio_out_named(dev, &s->miso_output_pin, "SPI_MISO", 1);

--- a/include/hw/ssi/spi_gpio.h
+++ b/include/hw/ssi/spi_gpio.h
@@ -37,7 +37,14 @@ struct SpiGpioState {
     SSIBus *spi;
     AspeedGPIOState *aspeed_gpio;
 
-    int clk, mosi, cs;
+    int mode;
+    int clk_counter;
+
+    bool CIDLE, CPHA;
+    uint32_t output_byte;
+    uint32_t input_byte;
+
+    bool clk, mosi, cs, miso;
     qemu_irq miso_output_pin, cs_output_pin;
 };
 


### PR DESCRIPTION
Signed-off-by: Iris Chen <irischenlj@fb.com>

Adds the encoding and decoding logic for the generic spi gpio model created.
Uses leading/trailing edges.
P509934987: showing the log with debug statements for tmpdin/tmpdout values and leading/trailing edges.