### PR TITLE
hw: m25p80: add device reset for m25p80 in the spi gpio controller

### DIFF
--- a/hw/arm/aspeed.c
+++ b/hw/arm/aspeed.c
@@ -379,7 +379,7 @@ static void aspeed_machine_init(MachineState *machine)
 
     SpiGpioState *spi_gpio = SPI_GPIO(qdev_new(TYPE_SPI_GPIO));
     spi_gpio->aspeed_gpio = &bmc->soc.gpio;
-    qdev_realize(DEVICE(spi_gpio), NULL, &error_fatal);
+    sysbus_realize(SYS_BUS_DEVICE(spi_gpio), &error_fatal);
 
     DeviceState *m25p80 = qdev_new("n25q256a");
     qdev_realize(m25p80, BUS(spi_gpio->spi), &error_fatal);

--- a/hw/ssi/spi_gpio.c
+++ b/hw/ssi/spi_gpio.c
@@ -152,7 +152,7 @@ static void SPI_GPIO_class_init(ObjectClass *klass, void *data)
 
 static const TypeInfo SPI_GPIO_info = {
     .name           = TYPE_SPI_GPIO,
-    .parent         = TYPE_DEVICE,
+    .parent         = TYPE_SYS_BUS_DEVICE,
     .instance_size  = sizeof(SpiGpioState),
     .class_init     = SPI_GPIO_class_init,
 };

--- a/include/hw/ssi/spi_gpio.h
+++ b/include/hw/ssi/spi_gpio.h
@@ -33,7 +33,7 @@
 OBJECT_DECLARE_SIMPLE_TYPE(SpiGpioState, SPI_GPIO);
 
 struct SpiGpioState {
-    DeviceState parent;
+    SysBusDevice parent;
     SSIBus *spi;
     AspeedGPIOState *aspeed_gpio;
 


### PR DESCRIPTION
Signed-off-by: Iris Chen <irischenlj@fb.com>

m25p80 needs to be reset. Looking for suggestions on better ways to do this