### PR TITLE
hw: m25p80: [spi gpio] fix prereading logic for controller 

### DIFF
--- a/hw/ssi/spi_gpio.c
+++ b/hw/ssi/spi_gpio.c
@@ -120,6 +120,7 @@ static void spi_gpio_realize(DeviceState *dev, Error **errp)
     SpiGpioState *s = SPI_GPIO(dev);
 
     s->spi = ssi_create_bus(dev, "spi");
+    s->spi->preread = true;
 
     s->mode = 0;
     s->clk_counter = 0;

--- a/hw/ssi/ssi.c
+++ b/hw/ssi/ssi.c
@@ -19,10 +19,6 @@
 #include "qapi/error.h"
 #include "qom/object.h"
 
-struct SSIBus {
-    BusState parent_obj;
-};
-
 #define TYPE_SSI_BUS "SSI"
 OBJECT_DECLARE_SIMPLE_TYPE(SSIBus, SSI_BUS)
 

--- a/include/hw/ssi/ssi.h
+++ b/include/hw/ssi/ssi.h
@@ -30,6 +30,11 @@ enum SSICSMode {
     SSI_CS_HIGH,
 };
 
+struct SSIBus {
+    BusState parent_obj;
+    bool preread;
+};
+
 /* Peripherals.  */
 struct SSIPeripheralClass {
     DeviceClass parent_class;


### PR DESCRIPTION
Signed-off-by: Iris Chen <irischenlj@fb.com>

Log: P512533495

```
[    8.282023] spi-nor spi2.0: n25q256a (32768 Kbytes)
[    8.292568] libphy: Fixed MDIO Bus: probed
```